### PR TITLE
Fix Playnite 9 settings, revert Newtonsoft.Json to 10.0.1

### DIFF
--- a/SwitchDisplay.cs
+++ b/SwitchDisplay.cs
@@ -10,7 +10,7 @@ using Playnite.SDK.Events;
 
 namespace SwitchDisplay
 {
-    public class SwitchDisplay : Plugin
+    public class SwitchDisplay : GenericPlugin
     {
 
         private static readonly ILogger logger = LogManager.GetLogger();
@@ -34,6 +34,11 @@ namespace SwitchDisplay
             Handler = new DisplayHandler();
             AudioEnumerator = new MMDeviceEnumerator();
             _policyConfigClient = new PolicyConfigClient();
+
+            Properties = new GenericPluginProperties
+            {
+                HasSettings = true
+            };
         }
 
 

--- a/SwitchDisplay.csproj
+++ b/SwitchDisplay.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NAudio" Version="2.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsBase" />

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,7 +1,7 @@
 ﻿Id: SwitchDisplay
 Name: Switch Display
 Author: Konnogatto
-Version: 0.0.4
+Version: 0.0.5
 Module: SwitchDisplay.dll
 Type: GenericPlugin
 Icon: icon.png

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,10 @@
+AddonId: PCGamingWikiMetadata_c038558e-427b-4551-be4c-be7009ce5a8d
+Packages:
+- Version: 0.0.5
+  RequiredApiVersion: 6.0.0
+  ReleaseDate: 2021-10-03
+  PackageUrl: https://github.com/konnogatto/SwitchDisplay/releases/download/v0.0.4/Switch_Display_0_0_5.pext
+  Changelog:
+    - Support for Playnite 9
+    - Update NAudio dependency version
+

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,10 @@
+AddonId: konnogatto_SwitchDisplay
+Packages:
+- Version: 0.0.5
+  RequiredApiVersion: 6.0.0
+  ReleaseDate: 2021-10-03
+  PackageUrl: https://github.com/konnogatto/SwitchDisplay/releases/download/v0.0.4/Switch_Display_0_0_5.pext
+  Changelog:
+    - Support for Playnite 9
+    - Update NAudio dependency version
+


### PR DESCRIPTION
- Fixed Switch Display settings not appearing in menu
- Reverted newtonsoft dependency to 10.0.1. 13.0.1 caused the extension to fail to load on Playnite start (seemingly need to match version Playnite uses)

```
03-10 06:56:27.664|ERROR|ExtensionFactory:Failed to load plugin: Switch Display
System.IO.FileNotFoundException: Could not load file or assembly 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed' or one of its dependencies. The system cannot find the file specified.
File name: 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
```
