### PR TITLE
Fixing AddonId reference

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-AddonId: konnogatto_SwitchDisplay
+AddonId: SwitchDisplay
 Packages:
 - Version: 0.0.6
   RequiredApiVersion: 6.0.0


### PR DESCRIPTION
AddonId currently doesn't match with what's actually used by the extension and with what's submitted in add-on database.