### PR TITLE
Auto detect audio device

### DIFF
--- a/SwitchDisplay.cs
+++ b/SwitchDisplay.cs
@@ -27,6 +27,8 @@ namespace SwitchDisplay
 
         public DisplayHandler Handler { get; set; }
 
+        private string initialAudioDevice;
+
         public SwitchDisplay(IPlayniteAPI api) : base(api)
         {
             settings = new SwitchDisplaySettings(this);
@@ -59,6 +61,12 @@ namespace SwitchDisplay
                 //Audio
                 if (settings.SwitchAudio && settings.FullScreenAudioDeviceList.Count > 0)
                 {
+                    //save current audio device ID before switching
+                    if (settings.AutoDetectAudioDevice)
+                    {
+                        initialAudioDevice = AudioEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia).ID;
+                    }
+
                     //search available device
                     foreach(KeyValuePair<string, string> device in settings.FullScreenAudioDeviceList)
                     {
@@ -99,7 +107,8 @@ namespace SwitchDisplay
                 //Audio
                 if (settings.SwitchAudio && !String.IsNullOrEmpty(settings.DefaultAudioDevice))
                 {
-                    _policyConfigClient.SetDefaultEndpoint(settings.DefaultAudioDevice, Role.Multimedia);
+                    //switch back to initialAudioDevice if auto detect is enabled, otherwise siwtch back to settings.DefaultAudioDevice
+                    _policyConfigClient.SetDefaultEndpoint(settings.AutoDetectAudioDevice ? initialAudioDevice : settings.DefaultAudioDevice, Role.Multimedia);
                 }
             }
         }

--- a/SwitchDisplaySettings.cs
+++ b/SwitchDisplaySettings.cs
@@ -26,6 +26,8 @@ namespace SwitchDisplay
         public bool SwitchDisplays { get; set; } = true;
 
         public bool SwitchAudio { get; set; } = true;
+        public bool AutoDetectAudioDevice { get; set; } = false;
+
 
         [DontSerialize]
         private Dictionary<string, string> _audioDevices;
@@ -52,6 +54,7 @@ namespace SwitchDisplay
                 FullScreenAudioDeviceList = savedSettings.FullScreenAudioDeviceList;
                 SwitchDisplays = savedSettings.SwitchDisplays;
                 SwitchAudio = savedSettings.SwitchAudio;
+                AutoDetectAudioDevice = savedSettings.AutoDetectAudioDevice;
             }
 
         }

--- a/SwitchDisplaySettingsView.xaml
+++ b/SwitchDisplaySettingsView.xaml
@@ -34,5 +34,7 @@
         </Grid>
         <TextBlock Text="Default Audiodevice:"/>
         <ComboBox ItemsSource="{Binding EnumerateAudioDevices}" SelectedValue="{Binding DefaultAudioDevice, Mode=TwoWay}" SelectedValuePath="Key" DisplayMemberPath="Value" />
+        <Separator Height="5" Margin="0"/>
+        <CheckBox IsChecked="{Binding AutoDetectAudioDevice}" Content="Auto detect audio device" />
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
Added an option to detect the active audio device at runtime prior to switching to fullscreen and switch back to that.
Useful if a user has multiple audio devices and wants to switch back to whatever one was active before opening fullscreen mode.